### PR TITLE
Fix compatibility with Python 3.10

### DIFF
--- a/bitwarden_pyro/util/config.py
+++ b/bitwarden_pyro/util/config.py
@@ -160,7 +160,7 @@ class ConfigLoader:
         items = []
         for key, value in config.items():
             new_key = parent_key + sep + key if parent_key else key
-            if isinstance(value, collections.MutableMapping):
+            if isinstance(value, collections.abc.MutableMapping):
                 items.extend(
                     self.__flatten_config(
                         value, new_key, sep=sep

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from bitwarden_pyro.settings import NAME, VERSION
 with open('README.md', encoding='utf-8') as f:
     long_description = f.read()
 
-setuptools.setup(name='bitwarden_pyro',
+setuptools.setup(name='bitwarden-pyro',
                  version=VERSION,
                  description='Bitwarden python interface built with Rofi',
                  url='https://github.com/mihalea/bitwarden-pyro',


### PR DESCRIPTION
Fixing two minor issues that prevented the package from working in Python 3.10
(which means it's broken in the AUR currently)

- Use non-deprected `collections.abc.MutableMapping`
- Use dash in package name to prevent a failure to load package metadata
